### PR TITLE
feat(extension): implement service worker persistence with Chrome Alarms API

### DIFF
--- a/mcp-browser-extension/manifest.json
+++ b/mcp-browser-extension/manifest.json
@@ -7,7 +7,8 @@
     "activeTab",
     "tabs",
     "storage",
-    "scripting"
+    "scripting",
+    "alarms"
   ],
   "host_permissions": [
     "http://localhost/*",


### PR DESCRIPTION
## Summary
Implements service worker persistence using Chrome Alarms API to resolve the critical issue where Chrome suspends service workers after 30 seconds of inactivity, breaking reconnection and server scanning logic.

## Changes
- **manifest.json**: Added `alarms` permission for Chrome Alarms API
- **background-enhanced.js**: Refactored timer logic to use persistent alarms

### Key Implementation
1. **Chrome Alarms Event Listener**: Routes `reconnect`, `serverScan`, and `heartbeat` alarms
2. **Heartbeat Mechanism**: Keeps service worker and WebSocket alive with 15-second pings
3. **Persistent Server Scanning**: 30-second periodic alarm instead of `setInterval`
4. **Reliable Reconnection**: 5-second alarm-based reconnect instead of `setTimeout`

### Before/After
| Timer Type | Before (Broken) | After (Persistent) |
|------------|-----------------|---------------------|
| Reconnect | `setTimeout(autoConnect, 5000)` | `chrome.alarms.create('reconnect')` |
| Server Scan | `setInterval(scanForServers, 30000)` | `chrome.alarms.create('serverScan')` |
| Keepalive | None | `chrome.alarms.create('heartbeat')` |

## Testing
- [ ] Extension loads without errors
- [ ] Server connection established
- [ ] Wait 60+ seconds - connection persists
- [ ] Disconnect server - reconnection attempts continue
- [ ] Check chrome://extensions logs for alarm triggers

## Related
Closes #7

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)