### PR TITLE
feat(extension): implement client-side heartbeat with pong timeout detection

### DIFF
--- a/src/services/websocket_service.py
+++ b/src/services/websocket_service.py
@@ -151,6 +151,15 @@ class WebSocketService:
             data = json.loads(message)
             message_type = data.get("type", "unknown")
 
+            # Handle heartbeat - respond with pong immediately
+            if message_type == "heartbeat":
+                pong_response = {
+                    "type": "pong",
+                    "timestamp": data.get("timestamp", 0)
+                }
+                await self.send_message(websocket, pong_response)
+                return
+
             # Handle server info request
             if message_type == "server_info":
                 import os


### PR DESCRIPTION
## Summary
Implements client-side heartbeat with pong timeout detection to quickly detect unresponsive servers instead of waiting for TCP timeout.

## Changes

### Extension (background-enhanced.js)
- Added heartbeat state: `lastPongTime`, `HEARTBEAT_INTERVAL` (15s), `PONG_TIMEOUT` (10s)
- Updated `sendHeartbeat()` to check pong timeout before sending
- Added pong message handler to update `lastPongTime`
- Reset `lastPongTime` on new connection

### Backend (websocket_service.py)
- Added heartbeat message handler
- Returns pong with original timestamp

## Timeout Logic
```
Connection opens → lastPongTime = now
Every 15s: Check if (now - lastPongTime) > 25s
  - If yes: Close connection, reconnect
  - If no: Send heartbeat
Server responds with pong → lastPongTime = now
```

## Testing
- [ ] Connect to server, verify heartbeat sent every 15s
- [ ] Verify pong responses logged
- [ ] Stop server without closing WebSocket - should reconnect within 25s
- [ ] Normal disconnect - should reconnect normally

## Related
- Depends on: #7 (Chrome Alarms), #9 (Port Keepalive)
- Closes #10

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)