### PR TITLE
feat: Multi-Connection Manager (#16)

### DIFF
--- a/mcp-browser-extension/background-enhanced.js
+++ b/mcp-browser-extension/background-enhanced.js
@@ -4,6 +4,9 @@
  * - Multi-server discovery
  * - Project identification
  * - Smart port selection
+ * - Multi-connection manager (supports up to 10 simultaneous connections)
+ * - Per-connection state management (heartbeat, queues, sequences)
+ * - Tab-to-connection routing
  */
 
 // Configuration
@@ -31,37 +34,40 @@ const STATUS_COLORS = {
 
 // State management
 let activeServers = new Map(); // port -> server info
-let currentConnection = null;
-let messageQueue = [];
 let extensionState = 'starting'; // 'starting', 'scanning', 'idle', 'connected', 'error'
 
 // Port to project mapping for faster reconnection
 let portProjectMap = {}; // port -> { project_id, project_name, project_path, last_seen }
 
-// Connection handshake state
-let connectionReady = false;
-let lastSequenceReceived = 0;
-
 // Gap detection configuration
 const GAP_DETECTION_ENABLED = true;
 const MAX_GAP_SIZE = 50; // Max messages to request in gap recovery
-let pendingGapRecovery = false;
-let outOfOrderBuffer = []; // Buffer for messages that arrive before gap is filled
 
-// Heartbeat state
-let lastPongTime = Date.now();
+// Heartbeat configuration
 const HEARTBEAT_INTERVAL = 15000; // 15 seconds
 const PONG_TIMEOUT = 10000; // 10 seconds (25s total before timeout)
 
 // Exponential backoff configuration
-let reconnectAttempts = 0;
 const BASE_RECONNECT_DELAY = 1000;  // 1 second
 const MAX_RECONNECT_DELAY = 30000;  // 30 seconds max
+
+// Maximum simultaneous connections
+const MAX_CONNECTIONS = 10;
 
 // Active ports to content scripts for keepalive
 const activePorts = new Map(); // tabId -> port
 
-// Connection status
+// LEGACY: Single connection fallback (deprecated)
+let currentConnection = null;
+let messageQueue = [];
+let connectionReady = false;
+let lastSequenceReceived = 0;
+let pendingGapRecovery = false;
+let outOfOrderBuffer = [];
+let lastPongTime = Date.now();
+let reconnectAttempts = 0;
+
+// Connection status (LEGACY - maintained for backward compatibility)
 const connectionStatus = {
   connected: false,
   port: null,
@@ -72,6 +78,681 @@ const connectionStatus = {
   connectionTime: null,
   availableServers: []
 };
+
+/**
+ * ConnectionManager - Manages multiple simultaneous WebSocket connections
+ * Supports N connections with per-connection state, heartbeat, and message queuing
+ */
+class ConnectionManager {
+  constructor() {
+    this.connections = new Map(); // port -> connection object
+    this.tabConnections = new Map(); // tabId -> port
+    this.primaryPort = null; // Currently active/primary connection for badge display
+  }
+
+  /**
+   * Create or return existing connection for a port
+   * @param {number} port - Port number to connect to
+   * @param {Object} projectInfo - Optional project information
+   * @returns {Promise<Object>} Connection object
+   */
+  async connectToBackend(port, projectInfo = null) {
+    console.log(`[ConnectionManager] Connecting to port ${port}...`);
+
+    // Check connection limit
+    if (!this.connections.has(port) && this.connections.size >= MAX_CONNECTIONS) {
+      throw new Error(`Maximum connections (${MAX_CONNECTIONS}) reached`);
+    }
+
+    // Return existing connection if already connected
+    if (this.connections.has(port)) {
+      const conn = this.connections.get(port);
+      if (conn.ws && conn.ws.readyState === WebSocket.OPEN) {
+        console.log(`[ConnectionManager] Reusing existing connection to port ${port}`);
+        return conn;
+      }
+      // Clean up stale connection
+      await this.disconnectBackend(port);
+    }
+
+    // Create new connection object
+    const connection = {
+      ws: null,
+      port: port,
+      projectId: projectInfo?.project_id || null,
+      projectName: projectInfo?.project_name || projectInfo?.projectName || `Port ${port}`,
+      projectPath: projectInfo?.project_path || projectInfo?.projectPath || '',
+      tabs: new Set(),
+      messageQueue: [],
+      connectionReady: false,
+      lastSequence: 0,
+      reconnectAttempts: 0,
+      heartbeatInterval: null,
+      lastPongTime: Date.now(),
+      pendingGapRecovery: false,
+      outOfOrderBuffer: []
+    };
+
+    try {
+      // Create WebSocket
+      const ws = new WebSocket(`ws://localhost:${port}`);
+      connection.ws = ws;
+
+      // Wait for connection to open
+      await new Promise((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          ws.close();
+          reject(new Error(`Connection timeout for port ${port}`));
+        }, 3000);
+
+        ws.onopen = async () => {
+          clearTimeout(timeout);
+          console.log(`[ConnectionManager] WebSocket opened for port ${port}`);
+
+          // Load last sequence from storage
+          const storageKey = `mcp_last_sequence_${port}`;
+          const result = await chrome.storage.local.get(storageKey);
+          connection.lastSequence = result[storageKey] || 0;
+
+          // Send connection_init handshake
+          const initMessage = {
+            type: 'connection_init',
+            lastSequence: connection.lastSequence,
+            extensionVersion: chrome.runtime.getManifest().version,
+            capabilities: ['console_capture', 'dom_interaction']
+          };
+
+          try {
+            ws.send(JSON.stringify(initMessage));
+            console.log(`[ConnectionManager] Sent connection_init for port ${port} with lastSequence: ${connection.lastSequence}`);
+          } catch (e) {
+            console.error(`[ConnectionManager] Failed to send connection_init for port ${port}:`, e);
+            reject(e);
+            return;
+          }
+
+          resolve();
+        };
+
+        ws.onerror = (error) => {
+          clearTimeout(timeout);
+          console.error(`[ConnectionManager] Connection error for port ${port}:`, error);
+          reject(error);
+        };
+
+        ws.onclose = () => {
+          clearTimeout(timeout);
+          reject(new Error(`Connection closed for port ${port}`));
+        };
+      });
+
+      // Set up message handlers
+      this._setupConnectionHandlers(connection);
+
+      // Store connection
+      this.connections.set(port, connection);
+
+      // Set as primary if it's the first connection
+      if (!this.primaryPort) {
+        this.primaryPort = port;
+      }
+
+      console.log(`[ConnectionManager] Successfully connected to port ${port} (${connection.projectName})`);
+      return connection;
+
+    } catch (error) {
+      console.error(`[ConnectionManager] Failed to connect to port ${port}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Disconnect from a specific backend
+   * @param {number} port - Port to disconnect from
+   */
+  async disconnectBackend(port) {
+    console.log(`[ConnectionManager] Disconnecting from port ${port}...`);
+
+    const connection = this.connections.get(port);
+    if (!connection) {
+      console.log(`[ConnectionManager] No connection found for port ${port}`);
+      return;
+    }
+
+    // Stop heartbeat
+    if (connection.heartbeatInterval) {
+      clearInterval(connection.heartbeatInterval);
+      connection.heartbeatInterval = null;
+    }
+
+    // Close WebSocket
+    if (connection.ws) {
+      try {
+        connection.ws.close();
+      } catch (e) {
+        console.error(`[ConnectionManager] Error closing WebSocket for port ${port}:`, e);
+      }
+    }
+
+    // Save last sequence
+    const storageKey = `mcp_last_sequence_${port}`;
+    await chrome.storage.local.set({ [storageKey]: connection.lastSequence });
+
+    // Save message queue if not empty
+    if (connection.messageQueue.length > 0) {
+      const queueKey = `mcp_message_queue_${port}`;
+      await chrome.storage.local.set({ [queueKey]: connection.messageQueue.slice(-MAX_QUEUE_SIZE) });
+    }
+
+    // Remove all tab associations
+    for (const [tabId, tabPort] of this.tabConnections.entries()) {
+      if (tabPort === port) {
+        this.tabConnections.delete(tabId);
+      }
+    }
+
+    // Remove connection
+    this.connections.delete(port);
+
+    // Update primary port if this was primary
+    if (this.primaryPort === port) {
+      const remainingPorts = Array.from(this.connections.keys());
+      this.primaryPort = remainingPorts.length > 0 ? remainingPorts[0] : null;
+    }
+
+    console.log(`[ConnectionManager] Disconnected from port ${port}`);
+  }
+
+  /**
+   * Get connection object for a specific tab
+   * @param {number} tabId - Tab ID
+   * @returns {Object|null} Connection object or null
+   */
+  getConnectionForTab(tabId) {
+    const port = this.tabConnections.get(tabId);
+    if (!port) {
+      return null;
+    }
+    return this.connections.get(port) || null;
+  }
+
+  /**
+   * Assign a tab to a specific connection
+   * @param {number} tabId - Tab ID
+   * @param {number} port - Port number
+   */
+  assignTabToConnection(tabId, port) {
+    const connection = this.connections.get(port);
+    if (!connection) {
+      console.warn(`[ConnectionManager] Cannot assign tab ${tabId} to port ${port} - connection not found`);
+      return;
+    }
+
+    // Remove from previous connection if exists
+    const previousPort = this.tabConnections.get(tabId);
+    if (previousPort && previousPort !== port) {
+      const prevConn = this.connections.get(previousPort);
+      if (prevConn) {
+        prevConn.tabs.delete(tabId);
+      }
+    }
+
+    // Assign to new connection
+    connection.tabs.add(tabId);
+    this.tabConnections.set(tabId, port);
+    console.log(`[ConnectionManager] Assigned tab ${tabId} to port ${port}`);
+  }
+
+  /**
+   * Remove a tab from all connections
+   * @param {number} tabId - Tab ID
+   */
+  removeTab(tabId) {
+    const port = this.tabConnections.get(tabId);
+    if (port) {
+      const connection = this.connections.get(port);
+      if (connection) {
+        connection.tabs.delete(tabId);
+        console.log(`[ConnectionManager] Removed tab ${tabId} from port ${port}`);
+      }
+      this.tabConnections.delete(tabId);
+    }
+  }
+
+  /**
+   * Send message through the connection associated with a tab
+   * @param {number} tabId - Tab ID
+   * @param {Object} message - Message to send
+   * @returns {Promise<boolean>} Success status
+   */
+  async sendMessage(tabId, message) {
+    const connection = this.getConnectionForTab(tabId);
+    if (!connection) {
+      console.warn(`[ConnectionManager] No connection found for tab ${tabId}, message queued`);
+      return false;
+    }
+
+    return this._sendToConnection(connection, message);
+  }
+
+  /**
+   * Broadcast message to all active connections
+   * @param {Object} message - Message to send
+   * @returns {Promise<number>} Number of successful sends
+   */
+  async broadcastToAll(message) {
+    let successCount = 0;
+    for (const connection of this.connections.values()) {
+      const success = await this._sendToConnection(connection, message);
+      if (success) successCount++;
+    }
+    console.log(`[ConnectionManager] Broadcast sent to ${successCount}/${this.connections.size} connections`);
+    return successCount;
+  }
+
+  /**
+   * Get list of active connections
+   * @returns {Array} Array of connection info objects
+   */
+  getActiveConnections() {
+    return Array.from(this.connections.values()).map(conn => ({
+      port: conn.port,
+      projectId: conn.projectId,
+      projectName: conn.projectName,
+      projectPath: conn.projectPath,
+      tabCount: conn.tabs.size,
+      queueSize: conn.messageQueue.length,
+      ready: conn.connectionReady,
+      isPrimary: conn.port === this.primaryPort
+    }));
+  }
+
+  /**
+   * Internal: Send message to a specific connection
+   * @private
+   */
+  async _sendToConnection(connection, message) {
+    if (connection.ws && connection.ws.readyState === WebSocket.OPEN && connection.connectionReady) {
+      try {
+        connection.ws.send(JSON.stringify(message));
+        return true;
+      } catch (e) {
+        console.error(`[ConnectionManager] Failed to send message to port ${connection.port}:`, e);
+        return false;
+      }
+    } else {
+      // Queue message
+      connection.messageQueue.push(message);
+      if (connection.messageQueue.length > MAX_QUEUE_SIZE) {
+        connection.messageQueue.shift();
+      }
+      // Persist queue
+      const queueKey = `mcp_message_queue_${connection.port}`;
+      await chrome.storage.local.set({ [queueKey]: connection.messageQueue.slice(-MAX_QUEUE_SIZE) });
+      return false;
+    }
+  }
+
+  /**
+   * Internal: Set up WebSocket event handlers for a connection
+   * @private
+   */
+  _setupConnectionHandlers(connection) {
+    const { ws, port } = connection;
+
+    ws.onmessage = async (event) => {
+      try {
+        const data = JSON.parse(event.data);
+
+        // Handle connection_ack
+        if (data.type === 'connection_ack') {
+          console.log(`[ConnectionManager] Connection acknowledged for port ${port}`);
+          connection.connectionReady = true;
+
+          // Update project info if provided
+          if (data.project_id) {
+            connection.projectId = data.project_id;
+            connection.projectName = data.project_name || connection.projectName;
+            connection.projectPath = data.project_path || connection.projectPath;
+
+            // Update port-project mapping
+            await updatePortProjectMapping(port, {
+              project_id: data.project_id,
+              project_name: data.project_name,
+              project_path: data.project_path
+            });
+          }
+
+          // Handle replayed messages
+          if (data.replay && Array.isArray(data.replay)) {
+            console.log(`[ConnectionManager] Receiving ${data.replay.length} replayed messages for port ${port}`);
+            for (const msg of data.replay) {
+              if (msg.sequence !== undefined && msg.sequence > connection.lastSequence) {
+                connection.lastSequence = msg.sequence;
+              }
+            }
+          }
+
+          // Update last sequence
+          if (data.currentSequence !== undefined) {
+            connection.lastSequence = data.currentSequence;
+            const storageKey = `mcp_last_sequence_${port}`;
+            await chrome.storage.local.set({ [storageKey]: connection.lastSequence });
+          }
+
+          // Start heartbeat
+          this._startHeartbeat(connection);
+
+          // Flush message queue
+          await this._flushMessageQueue(connection);
+
+          // Update status if this is primary connection
+          if (this.primaryPort === port) {
+            this._updateGlobalStatus();
+          }
+
+          return;
+        }
+
+        // Handle pong
+        if (data.type === 'pong') {
+          connection.lastPongTime = Date.now();
+          console.log(`[ConnectionManager] Pong received from port ${port}`);
+          return;
+        }
+
+        // Handle gap recovery
+        if (data.type === 'gap_recovery_response') {
+          console.log(`[ConnectionManager] Gap recovery response received for port ${port}`);
+          connection.pendingGapRecovery = false;
+
+          if (data.messages && Array.isArray(data.messages)) {
+            for (const msg of data.messages) {
+              if (msg.sequence !== undefined && msg.sequence > connection.lastSequence) {
+                connection.lastSequence = msg.sequence;
+              }
+            }
+
+            const storageKey = `mcp_last_sequence_${port}`;
+            await chrome.storage.local.set({ [storageKey]: connection.lastSequence });
+
+            this._processBufferedMessages(connection);
+          }
+
+          return;
+        }
+
+        // Handle sequenced messages
+        if (data.sequence !== undefined) {
+          const shouldProcess = this._checkSequenceGap(connection, data.sequence);
+          if (!shouldProcess) {
+            return;
+          }
+          connection.lastSequence = data.sequence;
+        }
+
+        // Handle regular server messages
+        this._handleServerMessage(connection, data);
+
+      } catch (error) {
+        console.error(`[ConnectionManager] Failed to parse message from port ${port}:`, error);
+      }
+    };
+
+    ws.onerror = (error) => {
+      console.error(`[ConnectionManager] WebSocket error for port ${port}:`, error);
+    };
+
+    ws.onclose = async () => {
+      console.log(`[ConnectionManager] Connection closed for port ${port}`);
+
+      // Stop heartbeat
+      if (connection.heartbeatInterval) {
+        clearInterval(connection.heartbeatInterval);
+        connection.heartbeatInterval = null;
+      }
+
+      // Save state
+      const storageKey = `mcp_last_sequence_${port}`;
+      await chrome.storage.local.set({ [storageKey]: connection.lastSequence });
+
+      // Schedule reconnect with exponential backoff
+      connection.reconnectAttempts++;
+      const delay = this._calculateReconnectDelay(connection.reconnectAttempts);
+      console.log(`[ConnectionManager] Scheduling reconnect for port ${port} in ${delay}ms (attempt ${connection.reconnectAttempts})`);
+
+      setTimeout(async () => {
+        try {
+          // Remove old connection
+          this.connections.delete(port);
+
+          // Attempt reconnect
+          await this.connectToBackend(port, {
+            project_id: connection.projectId,
+            project_name: connection.projectName,
+            project_path: connection.projectPath
+          });
+
+          // Reassign tabs
+          for (const tabId of connection.tabs) {
+            this.assignTabToConnection(tabId, port);
+          }
+
+        } catch (error) {
+          console.error(`[ConnectionManager] Reconnect failed for port ${port}:`, error);
+        }
+      }, delay);
+
+      // Update global status
+      this._updateGlobalStatus();
+    };
+  }
+
+  /**
+   * Internal: Start heartbeat for a connection
+   * @private
+   */
+  _startHeartbeat(connection) {
+    if (connection.heartbeatInterval) {
+      clearInterval(connection.heartbeatInterval);
+    }
+
+    console.log(`[ConnectionManager] Starting heartbeat for port ${connection.port}`);
+    connection.heartbeatInterval = setInterval(() => {
+      if (connection.ws && connection.ws.readyState === WebSocket.OPEN) {
+        // Check for pong timeout
+        const timeSinceLastPong = Date.now() - connection.lastPongTime;
+        if (timeSinceLastPong > HEARTBEAT_INTERVAL + PONG_TIMEOUT) {
+          console.warn(`[ConnectionManager] Heartbeat timeout for port ${connection.port} - no pong for ${timeSinceLastPong}ms`);
+          connection.ws.close();
+          return;
+        }
+
+        // Send heartbeat
+        try {
+          connection.ws.send(JSON.stringify({
+            type: 'heartbeat',
+            timestamp: Date.now()
+          }));
+          console.log(`[ConnectionManager] Heartbeat sent to port ${connection.port}`);
+        } catch (e) {
+          console.warn(`[ConnectionManager] Heartbeat failed for port ${connection.port}:`, e);
+        }
+      } else {
+        clearInterval(connection.heartbeatInterval);
+        connection.heartbeatInterval = null;
+      }
+    }, HEARTBEAT_INTERVAL);
+  }
+
+  /**
+   * Internal: Flush message queue for a connection
+   * @private
+   */
+  async _flushMessageQueue(connection) {
+    if (!connection.ws || connection.ws.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    console.log(`[ConnectionManager] Flushing ${connection.messageQueue.length} queued messages for port ${connection.port}`);
+
+    while (connection.messageQueue.length > 0) {
+      const message = connection.messageQueue.shift();
+      try {
+        connection.ws.send(JSON.stringify(message));
+      } catch (e) {
+        console.error(`[ConnectionManager] Failed to send queued message to port ${connection.port}:`, e);
+        connection.messageQueue.unshift(message);
+        break;
+      }
+    }
+
+    // Clear stored queue
+    const queueKey = `mcp_message_queue_${connection.port}`;
+    await chrome.storage.local.remove(queueKey);
+  }
+
+  /**
+   * Internal: Check for sequence gaps
+   * @private
+   */
+  _checkSequenceGap(connection, incomingSequence) {
+    if (!GAP_DETECTION_ENABLED || incomingSequence === undefined) {
+      return true;
+    }
+
+    const expectedSequence = connection.lastSequence + 1;
+
+    if (incomingSequence === expectedSequence) {
+      return true;
+    }
+
+    if (incomingSequence <= connection.lastSequence) {
+      console.log(`[ConnectionManager] Duplicate message (seq ${incomingSequence}) for port ${connection.port}`);
+      return false;
+    }
+
+    const gapSize = incomingSequence - expectedSequence;
+    console.warn(`[ConnectionManager] Gap detected for port ${connection.port}: expected ${expectedSequence}, got ${incomingSequence} (gap: ${gapSize})`);
+
+    if (gapSize > MAX_GAP_SIZE) {
+      console.warn(`[ConnectionManager] Gap too large (${gapSize}) for port ${connection.port}, accepting and resetting`);
+      return true;
+    }
+
+    if (!connection.pendingGapRecovery) {
+      this._requestGapRecovery(connection, expectedSequence, incomingSequence - 1);
+    }
+
+    connection.outOfOrderBuffer.push({ sequence: incomingSequence });
+    return false;
+  }
+
+  /**
+   * Internal: Request gap recovery
+   * @private
+   */
+  _requestGapRecovery(connection, fromSequence, toSequence) {
+    if (!connection.ws || connection.ws.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    connection.pendingGapRecovery = true;
+    console.log(`[ConnectionManager] Requesting gap recovery for port ${connection.port}: sequences ${fromSequence} to ${toSequence}`);
+
+    try {
+      connection.ws.send(JSON.stringify({
+        type: 'gap_recovery',
+        fromSequence: fromSequence,
+        toSequence: toSequence
+      }));
+    } catch (e) {
+      console.error(`[ConnectionManager] Failed to request gap recovery for port ${connection.port}:`, e);
+      connection.pendingGapRecovery = false;
+    }
+  }
+
+  /**
+   * Internal: Process buffered messages
+   * @private
+   */
+  _processBufferedMessages(connection) {
+    if (connection.outOfOrderBuffer.length === 0) return;
+
+    connection.outOfOrderBuffer.sort((a, b) => a.sequence - b.sequence);
+
+    const stillBuffered = [];
+    for (const item of connection.outOfOrderBuffer) {
+      if (item.sequence === connection.lastSequence + 1) {
+        connection.lastSequence = item.sequence;
+      } else if (item.sequence > connection.lastSequence + 1) {
+        stillBuffered.push(item);
+      }
+    }
+
+    connection.outOfOrderBuffer = stillBuffered;
+  }
+
+  /**
+   * Internal: Calculate reconnect delay with exponential backoff
+   * @private
+   */
+  _calculateReconnectDelay(attempts) {
+    const exponentialDelay = Math.min(
+      BASE_RECONNECT_DELAY * Math.pow(2, attempts),
+      MAX_RECONNECT_DELAY
+    );
+
+    const jitter = exponentialDelay * 0.25 * (Math.random() - 0.5);
+    return Math.max(exponentialDelay + jitter, BASE_RECONNECT_DELAY);
+  }
+
+  /**
+   * Internal: Handle server message
+   * @private
+   */
+  _handleServerMessage(connection, data) {
+    // Route to original handler
+    handleServerMessage(data);
+  }
+
+  /**
+   * Internal: Update global connection status
+   * @private
+   */
+  _updateGlobalStatus() {
+    // Update legacy connectionStatus for backward compatibility
+    const primaryConn = this.primaryPort ? this.connections.get(this.primaryPort) : null;
+
+    if (primaryConn && primaryConn.connectionReady) {
+      connectionStatus.connected = true;
+      connectionStatus.port = primaryConn.port;
+      connectionStatus.projectName = primaryConn.projectName;
+      connectionStatus.projectPath = primaryConn.projectPath;
+      connectionStatus.lastError = null;
+      extensionState = 'connected';
+    } else if (this.connections.size > 0) {
+      // At least one connection exists
+      const anyConn = Array.from(this.connections.values())[0];
+      connectionStatus.connected = true;
+      connectionStatus.port = anyConn.port;
+      connectionStatus.projectName = anyConn.projectName;
+      connectionStatus.projectPath = anyConn.projectPath;
+      extensionState = 'connected';
+    } else {
+      connectionStatus.connected = false;
+      connectionStatus.port = null;
+      connectionStatus.projectName = null;
+      connectionStatus.projectPath = null;
+      extensionState = activeServers.size > 0 ? 'idle' : 'idle';
+    }
+
+    updateBadgeStatus();
+  }
+}
+
+// Initialize ConnectionManager
+const connectionManager = new ConnectionManager();
 
 /**
  * Calculate reconnection delay with exponential backoff and jitter
@@ -968,13 +1649,16 @@ chrome.tabs.onRemoved.addListener((tabId) => {
     console.log(`[MCP Browser] Tab ${tabId} closed, removing port`);
     activePorts.delete(tabId);
   }
+
+  // Remove tab from ConnectionManager
+  connectionManager.removeTab(tabId);
 });
 
 // Handle messages from popup and content scripts
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.type === 'console_messages') {
     // Only process messages from the active tab
-    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    chrome.tabs.query({ active: true, currentWindow: true }, async (tabs) => {
       const activeTab = tabs[0];
 
       // Check if this message is from the active tab
@@ -989,8 +1673,18 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
           frameId: sender.frameId
         };
 
-        if (!sendToServer(batchMessage)) {
-          console.log('[MCP Browser] WebSocket not connected, message queued');
+        // Try ConnectionManager first (multi-connection mode)
+        const tabConnection = connectionManager.getConnectionForTab(sender.tab.id);
+        if (tabConnection) {
+          const sent = await connectionManager.sendMessage(sender.tab.id, batchMessage);
+          if (!sent) {
+            console.log(`[MCP Browser] Message queued for tab ${sender.tab.id}`);
+          }
+        } else {
+          // Fallback to legacy single-connection mode
+          if (!sendToServer(batchMessage)) {
+            console.log('[MCP Browser] WebSocket not connected, message queued');
+          }
         }
       } else {
         // Silently ignore messages from inactive tabs
@@ -1000,7 +1694,15 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
     sendResponse({ received: true });
   } else if (request.type === 'get_status') {
-    sendResponse(connectionStatus);
+    // Return enhanced status with all connections
+    const connections = connectionManager.getActiveConnections();
+    const enhancedStatus = {
+      ...connectionStatus,
+      multiConnection: true,
+      connections: connections,
+      totalConnections: connections.length
+    };
+    sendResponse(enhancedStatus);
   } else if (request.type === 'scan_servers') {
     // Scan for available servers
     scanForServers().then(servers => {
@@ -1008,23 +1710,55 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     });
     return true; // Keep channel open for async response
   } else if (request.type === 'connect_to_server') {
-    // Connect to specific server
+    // Connect to specific server using ConnectionManager
     const { port, serverInfo } = request;
-    connectToServer(port, serverInfo).then(success => {
-      sendResponse({ success: success });
+    connectionManager.connectToBackend(port, serverInfo).then(connection => {
+      sendResponse({ success: true, connection: {
+        port: connection.port,
+        projectName: connection.projectName,
+        projectPath: connection.projectPath
+      }});
+    }).catch(error => {
+      console.error(`[MCP Browser] Failed to connect to port ${port}:`, error);
+      sendResponse({ success: false, error: error.message });
     });
     return true; // Keep channel open for async response
   } else if (request.type === 'disconnect') {
-    // Disconnect from current server
-    if (currentConnection) {
-      currentConnection.close();
-      currentConnection = null;
+    // Disconnect from specific server or all servers
+    const { port } = request;
+    if (port) {
+      // Disconnect from specific port
+      connectionManager.disconnectBackend(port).then(() => {
+        sendResponse({ received: true, port: port });
+      });
+    } else {
+      // Disconnect from all (legacy behavior + all ConnectionManager connections)
+      if (currentConnection) {
+        currentConnection.close();
+        currentConnection = null;
+      }
+      // Disconnect all managed connections
+      const ports = Array.from(connectionManager.connections.keys());
+      Promise.all(ports.map(p => connectionManager.disconnectBackend(p))).then(() => {
+        clearConnectionState();
+        reconnectAttempts = 0;
+        sendResponse({ received: true, disconnectedAll: true });
+      });
     }
-    // Clear connection state on intentional disconnect
-    clearConnectionState();
-    // Reset reconnect attempts on manual disconnect
-    reconnectAttempts = 0;
-    sendResponse({ received: true });
+    return true; // Keep channel open for async response
+  } else if (request.type === 'assign_tab_to_port') {
+    // Assign a tab to a specific port/connection
+    const { tabId, port } = request;
+    try {
+      connectionManager.assignTabToConnection(tabId, port);
+      sendResponse({ success: true });
+    } catch (error) {
+      sendResponse({ success: false, error: error.message });
+    }
+  } else if (request.type === 'get_connections') {
+    // Get list of all active connections
+    const connections = connectionManager.getActiveConnections();
+    sendResponse({ connections: connections });
   }
 });
 


### PR DESCRIPTION
## Summary

Implements a `ConnectionManager` class enabling the extension to maintain N simultaneous WebSocket connections to different MCP browser backends.

Closes #16

### Core Features
- **ConnectionManager class** with `Map<port → connection>` tracking
- **Per-connection state**: ws, tabs, messageQueue, heartbeat, sequence tracking
- **Maximum 10 simultaneous connections** (configurable via `MAX_CONNECTIONS`)
- **Primary connection tracking** for badge display

### Key Methods
- `connectToBackend(port, projectInfo)` - Create/return connection
- `disconnectBackend(port)` - Close and cleanup connection
- `getConnectionForTab(tabId)` - Find connection for a tab
- `assignTabToConnection(tabId, port)` - Associate tab with connection
- `removeTab(tabId)` - Clean up when tab closes
- `sendMessage(tabId, message)` - Route through correct connection
- `broadcastToAll(message)` - Send to all connections
- `getActiveConnections()` - List all connections with stats

### Per-Connection Features
- ✅ Independent heartbeat timer with pong timeout detection
- ✅ Own message queue persisted to `chrome.storage.local`
- ✅ Own reconnection logic with exponential backoff
- ✅ Own sequence tracking for gap detection

### Integration
- `chrome.runtime.onMessage` routes through ConnectionManager
- Tab close handler cleans up connection associations
- Enhanced status API includes `multiConnection` info
- **Full backward compatibility** with legacy single-connection mode

## Test Plan
- [ ] Multiple simultaneous WebSocket connections supported
- [ ] Each connection tracks its own tabs
- [ ] Each connection has own message queue
- [ ] Connection lifecycle managed independently
- [ ] Maximum 10 connections enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)