### PR TITLE
feat: Connect to Existing Browser via CDP (#23)

### DIFF
--- a/docs/CDP_CONNECTION.md
+++ b/docs/CDP_CONNECTION.md
@@ -1,0 +1,512 @@
+# CDP Connection Guide
+
+Connect to your existing Chrome browser via Chrome DevTools Protocol (CDP) to use MCP Browser while preserving your browser session, cookies, and extensions.
+
+## Overview
+
+The CDP connection feature allows you to:
+- Connect to a **running Chrome instance** without launching a new browser
+- **Preserve browser state**: cookies, sessions, logged-in accounts
+- **Keep your extensions**: ad blockers, password managers, etc.
+- **Maintain browsing history** and settings
+- Use all MCP Browser features with your existing browser
+
+## Prerequisites
+
+1. **Google Chrome** (or Chromium-based browser)
+2. **Playwright** installed:
+   ```bash
+   pip install playwright
+   playwright install
+   ```
+3. **mcp-browser** package:
+   ```bash
+   pip install mcp-browser
+   ```
+
+## Quick Start
+
+### 1. Start Chrome with Remote Debugging
+
+You need to start Chrome with the `--remote-debugging-port` flag:
+
+#### macOS
+```bash
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --remote-debugging-port=9222
+```
+
+#### Linux
+```bash
+google-chrome --remote-debugging-port=9222
+# or
+chromium-browser --remote-debugging-port=9222
+```
+
+#### Windows
+```cmd
+"C:\Program Files\Google\Chrome\Application\chrome.exe" --remote-debugging-port=9222
+```
+
+**Important**: Close all Chrome instances before starting with CDP:
+```bash
+# macOS/Linux
+pkill -f "Google Chrome"
+
+# Windows (PowerShell)
+Stop-Process -Name chrome -Force
+```
+
+### 2. Test the Connection
+
+Use the CLI command to verify the connection:
+
+```bash
+mcp-browser connect
+```
+
+Or specify a custom port:
+
+```bash
+mcp-browser connect --cdp-port 9223
+```
+
+**Success Output:**
+```
+✓ Connection Successful
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Status              ✓ Connected
+Browser Version     Chrome/120.0.6099.109
+CDP Port            9222
+Active Pages        3
+```
+
+### 3. Configure MCP Browser to Use CDP
+
+Create or update your configuration file (`~/.mcp-browser/config.json`):
+
+```json
+{
+  "browser_control": {
+    "mode": "cdp",
+    "cdp_port": 9222,
+    "cdp_enabled": true,
+    "fallback_enabled": false
+  }
+}
+```
+
+**Configuration Options:**
+- `mode`: Set to `"cdp"` for CDP-only mode, or `"auto"` for automatic fallback
+- `cdp_port`: Port number where Chrome is running with CDP (default: 9222)
+- `cdp_enabled`: Enable CDP connection (default: true)
+- `fallback_enabled`: Allow fallback to extension/AppleScript if CDP fails
+
+## Usage with Claude Code
+
+Once configured, all MCP Browser tools will use your existing browser:
+
+```python
+# In Claude Code, MCP tools automatically use CDP connection
+# Example: Navigate to a URL (preserves cookies/session)
+await mcp.call_tool("browser_navigate", {"url": "https://example.com"})
+
+# Click elements (works with logged-in state)
+await mcp.call_tool("browser_click", {"selector": "#dashboard-link"})
+
+# Fill forms (auto-fill from saved passwords works!)
+await mcp.call_tool("browser_fill", {
+    "selector": "#search-input",
+    "value": "query"
+})
+```
+
+## Advanced Usage
+
+### Multiple Chrome Profiles
+
+Run different Chrome instances with different profiles and CDP ports:
+
+```bash
+# Profile 1 on port 9222
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+  --remote-debugging-port=9222 \
+  --user-data-dir=/tmp/chrome-profile-1
+
+# Profile 2 on port 9223
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+  --remote-debugging-port=9223 \
+  --user-data-dir=/tmp/chrome-profile-2
+```
+
+Connect to specific profile:
+```bash
+mcp-browser connect --cdp-port 9223
+```
+
+### Custom User Data Directory
+
+Preserve a specific Chrome profile:
+
+```bash
+# macOS/Linux
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+  --remote-debugging-port=9222 \
+  --user-data-dir="$HOME/.chrome-mcp-profile"
+
+# Windows
+chrome.exe --remote-debugging-port=9222 --user-data-dir="%USERPROFILE%\.chrome-mcp-profile"
+```
+
+### Headless Mode
+
+Run Chrome in headless mode (no visible window) with CDP:
+
+```bash
+# Headless with CDP
+google-chrome --headless --remote-debugging-port=9222
+```
+
+**Note**: Some websites detect headless mode and may block automation.
+
+## Programmatic Usage
+
+Use CDP connection in Python scripts:
+
+```python
+import asyncio
+from mcp_browser.services.browser_controller import (
+    BrowserController,
+    BrowserNotAvailableError
+)
+from mcp_browser.services import BrowserService, WebSocketService
+from mcp_browser.services.applescript_service import AppleScriptService
+
+async def connect_to_browser():
+    # Create service instances
+    websocket_service = WebSocketService(host="localhost", port_range=[8875, 8895])
+    browser_service = BrowserService()
+    applescript_service = AppleScriptService()
+
+    # Configure for CDP
+    config = {
+        "browser_control": {
+            "mode": "cdp",
+            "cdp_port": 9222,
+            "cdp_enabled": True
+        }
+    }
+
+    # Create controller
+    controller = BrowserController(
+        websocket_service=websocket_service,
+        browser_service=browser_service,
+        applescript_service=applescript_service,
+        config=config
+    )
+
+    try:
+        # Connect to existing browser
+        result = await controller.connect_to_existing_browser(cdp_port=9222)
+
+        if result["success"]:
+            print(f"Connected to {result['browser_version']}")
+            print(f"Active pages: {result['page_count']}")
+
+            # Use browser controller
+            await controller.navigate("https://example.com")
+            await controller.click(selector="button#submit")
+
+        else:
+            print(f"Connection failed: {result['error']}")
+
+    except BrowserNotAvailableError as e:
+        print(f"Browser not available: {e}")
+
+    finally:
+        await controller.close_cdp()
+
+# Run
+asyncio.run(connect_to_browser())
+```
+
+## Troubleshooting
+
+### Connection Refused
+
+**Problem**: `Cannot connect to Chrome on port 9222`
+
+**Solutions**:
+1. Ensure Chrome is running with `--remote-debugging-port=9222`
+2. Close all Chrome instances and restart with CDP flag
+3. Check if another process is using port 9222:
+   ```bash
+   # macOS/Linux
+   lsof -i :9222
+
+   # Windows
+   netstat -ano | findstr :9222
+   ```
+4. Try a different port (e.g., 9223)
+
+### Playwright Not Installed
+
+**Problem**: `Playwright not installed`
+
+**Solution**:
+```bash
+pip install playwright
+playwright install
+```
+
+### CDP Endpoint Returns 404
+
+**Problem**: `CDP endpoint returned status 404`
+
+**Solutions**:
+1. Verify Chrome is running with remote debugging
+2. Check the CDP port is correct
+3. Try accessing `http://localhost:9222/json/version` in a browser
+   - Should return JSON with browser version info
+   - If returns 404, Chrome CDP is not enabled
+
+### Port Already in Use
+
+**Problem**: `Address already in use: bind`
+
+**Solutions**:
+1. Find and kill the process using the port:
+   ```bash
+   # macOS/Linux
+   lsof -ti:9222 | xargs kill -9
+
+   # Windows
+   netstat -ano | findstr :9222
+   taskkill /PID <pid> /F
+   ```
+2. Use a different port number
+
+### No Pages Available
+
+**Problem**: `CDP connected but no pages available`
+
+**Solutions**:
+1. Open at least one tab in Chrome
+2. Navigate to a website (not `chrome://` URLs)
+3. Ensure the tab is not in incognito mode (CDP doesn't access incognito by default)
+
+### Connection Timeout
+
+**Problem**: `Connection to Chrome on port 9222 timed out`
+
+**Solutions**:
+1. Check firewall settings (allow local connections on CDP port)
+2. Verify Chrome is running and responsive
+3. Try restarting Chrome with CDP flag
+4. Increase timeout in code (default: 5 seconds)
+
+### Browser Crashes or Becomes Unresponsive
+
+**Problem**: Browser freezes during CDP usage
+
+**Solutions**:
+1. Close and restart Chrome with CDP
+2. Reduce concurrent operations
+3. Check system resources (CPU, memory)
+4. Update Chrome to latest version
+
+## Security Considerations
+
+### Local Access Only
+
+CDP should **only** be accessible locally. Never expose CDP to external networks:
+
+```bash
+# ✓ GOOD: Localhost only (default)
+chrome --remote-debugging-port=9222
+
+# ✗ BAD: Exposed to network
+chrome --remote-debugging-address=0.0.0.0 --remote-debugging-port=9222
+```
+
+### Firewall Configuration
+
+Ensure your firewall blocks external access to CDP ports:
+
+```bash
+# macOS
+sudo /usr/libexec/ApplicationFirewall/socketfilterfw --add chrome
+sudo /usr/libexec/ApplicationFirewall/socketfilterfw --block chrome
+
+# Linux (ufw)
+sudo ufw deny 9222
+
+# Windows Firewall
+netsh advfirewall firewall add rule name="Block CDP" dir=in action=block protocol=TCP localport=9222
+```
+
+### User Data Isolation
+
+Use separate user data directories for automation:
+
+```bash
+# Don't use your main profile for automation
+chrome --remote-debugging-port=9222 --user-data-dir=/tmp/chrome-automation
+```
+
+## Comparison: CDP vs Extension vs AppleScript
+
+| Feature | CDP | Extension | AppleScript |
+|---------|-----|-----------|-------------|
+| **Preserve Browser State** | ✅ Yes | ❌ No | ✅ Yes |
+| **Keep Extensions** | ✅ Yes | ❌ No | ✅ Yes |
+| **Performance** | ⚡ Fast | ⚡ Fastest | 🐌 Slow |
+| **Setup Complexity** | 🔧 Medium | 🟢 Easy | 🟢 Easy |
+| **Cross-Platform** | ✅ Yes | ✅ Yes | ❌ macOS only |
+| **Console Logs** | ❌ No* | ✅ Yes | ❌ No |
+| **Requires Chrome Restart** | ✅ Yes | ❌ No | ❌ No |
+
+*CDP can access console logs via Chrome DevTools Protocol, but this is not yet implemented in mcp-browser.
+
+## Best Practices
+
+### 1. Use Dedicated Chrome Profile
+
+Create a dedicated Chrome profile for MCP Browser automation:
+
+```bash
+mkdir -p ~/.chrome-mcp-profile
+chrome --remote-debugging-port=9222 --user-data-dir=~/.chrome-mcp-profile
+```
+
+**Benefits**:
+- Isolates automation from personal browsing
+- Prevents accidental data exposure
+- Easier to reset/clean
+
+### 2. Automate Chrome Startup
+
+Create a shell script or alias:
+
+```bash
+# ~/.bashrc or ~/.zshrc
+alias chrome-cdp='google-chrome --remote-debugging-port=9222 --user-data-dir=~/.chrome-mcp-profile &'
+```
+
+Usage:
+```bash
+chrome-cdp
+mcp-browser connect
+```
+
+### 3. Use Environment Variables
+
+Store CDP configuration in environment variables:
+
+```bash
+# ~/.bashrc or ~/.zshrc
+export MCP_BROWSER_CDP_PORT=9222
+export MCP_BROWSER_MODE=cdp
+```
+
+Reference in config:
+```json
+{
+  "browser_control": {
+    "mode": "${MCP_BROWSER_MODE}",
+    "cdp_port": "${MCP_BROWSER_CDP_PORT}"
+  }
+}
+```
+
+### 4. Monitor Connection Health
+
+Periodically check CDP connection:
+
+```bash
+# Check if CDP is accessible
+curl http://localhost:9222/json/version
+```
+
+### 5. Graceful Cleanup
+
+Always close CDP connections when done:
+
+```python
+try:
+    await controller.connect_to_existing_browser(9222)
+    # ... use browser ...
+finally:
+    await controller.close_cdp()
+```
+
+## FAQ
+
+### Can I use CDP with Firefox?
+
+No, CDP is specific to Chromium-based browsers (Chrome, Edge, Brave, etc.). Firefox uses a different protocol (Firefox DevTools Protocol).
+
+### Does CDP work with Brave/Edge?
+
+Yes! Any Chromium-based browser supports CDP:
+
+```bash
+# Brave
+/Applications/Brave\ Browser.app/Contents/MacOS/Brave\ Browser --remote-debugging-port=9222
+
+# Edge
+/Applications/Microsoft\ Edge.app/Contents/MacOS/Microsoft\ Edge --remote-debugging-port=9222
+```
+
+### Can I connect to remote Chrome instances?
+
+Yes, but **not recommended** for security reasons. If needed:
+
+```bash
+# Remote Chrome (insecure!)
+chrome --remote-debugging-address=0.0.0.0 --remote-debugging-port=9222
+
+# Connect from different machine
+mcp-browser connect --cdp-url http://remote-ip:9222
+```
+
+**Warning**: This exposes full browser control to anyone with network access!
+
+### Will CDP interfere with manual browsing?
+
+No, you can browse manually while CDP is connected. Both manual and automated actions will work simultaneously.
+
+### Can I use CDP and the extension together?
+
+Yes, in `"auto"` mode, MCP Browser will try the extension first and fall back to CDP:
+
+```json
+{
+  "browser_control": {
+    "mode": "auto",
+    "cdp_enabled": true,
+    "fallback_enabled": true
+  }
+}
+```
+
+## Related Documentation
+
+- [QUICK_REFERENCE.md](QUICK_REFERENCE.md) - MCP Browser command reference
+- [TROUBLESHOOTING.md](TROUBLESHOOTING.md) - General troubleshooting guide
+- [DEVELOPER.md](DEVELOPER.md) - Developer documentation
+- [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) - Official CDP documentation
+
+## Support
+
+For issues or questions:
+- GitHub Issues: https://github.com/masa/mcp-browser/issues
+- Documentation: https://github.com/masa/mcp-browser/docs
+- Discord Community: [Join here]
+
+---
+
+**Next Steps:**
+1. Start Chrome with CDP: `chrome --remote-debugging-port=9222`
+2. Test connection: `mcp-browser connect`
+3. Configure mode: Update `~/.mcp-browser/config.json`
+4. Start using MCP Browser with your existing browser session!

--- a/src/cli/commands/__init__.py
+++ b/src/cli/commands/__init__.py
@@ -1,6 +1,7 @@
 """CLI command modules."""
 
 from .browser import browser
+from .connect import connect
 from .dashboard import dashboard
 from .doctor import doctor
 from .extension import extension
@@ -23,4 +24,5 @@ __all__ = [
     "uninstall",
     "extension",
     "browser",
+    "connect",
 ]

--- a/src/cli/commands/connect.py
+++ b/src/cli/commands/connect.py
@@ -1,0 +1,197 @@
+"""Connect to existing browser via CDP command."""
+
+import asyncio
+import sys
+
+import click
+from rich.panel import Panel
+from rich.table import Table
+
+from ..utils import console
+
+# Import required for CDP connection
+try:
+    from ...services.browser_controller import BrowserController, BrowserNotAvailableError
+    from ...services import BrowserService, WebSocketService
+    from ...services.applescript_service import AppleScriptService
+    CDP_IMPORTS_AVAILABLE = True
+except ImportError:
+    CDP_IMPORTS_AVAILABLE = False
+
+
+@click.command()
+@click.option(
+    "--cdp-port",
+    default=9222,
+    type=int,
+    help="CDP port where Chrome is running (default: 9222)",
+)
+@click.pass_context
+def connect(ctx, cdp_port: int):
+    """🔌 Connect to existing Chrome browser via CDP.
+
+    \b
+    This command connects to a Chrome browser that's already running
+    with remote debugging enabled. Useful for preserving browser state
+    (cookies, sessions, extensions) while using MCP Browser.
+
+    \b
+    Prerequisites:
+      1. Start Chrome with remote debugging:
+         macOS:   /Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --remote-debugging-port=9222
+         Linux:   google-chrome --remote-debugging-port=9222
+         Windows: "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe" --remote-debugging-port=9222
+
+      2. Ensure Playwright is installed:
+         pip install playwright && playwright install
+
+    \b
+    Examples:
+      mcp-browser connect                    # Connect to port 9222 (default)
+      mcp-browser connect --cdp-port 9223    # Connect to custom port
+
+    \b
+    Once connected, you can use all MCP Browser features while preserving
+    your existing browser session, cookies, and installed extensions.
+    """
+    asyncio.run(_connect_command(cdp_port))
+
+
+async def _connect_command(cdp_port: int):
+    """Execute connect command."""
+    console.print(
+        Panel(
+            f"[bold cyan]🔌 Connecting to Chrome via CDP[/bold cyan]\n\n"
+            f"Port: {cdp_port}\n"
+            f"Checking browser availability...",
+            title="CDP Connection",
+            border_style="cyan",
+        )
+    )
+
+    if not CDP_IMPORTS_AVAILABLE:
+        console.print(
+            Panel(
+                "[red]✗ Required dependencies not available[/red]\n\n"
+                "Install Playwright to use CDP connection:\n"
+                "  [cyan]pip install playwright[/cyan]\n"
+                "  [cyan]playwright install[/cyan]",
+                title="Error",
+                border_style="red",
+            )
+        )
+        sys.exit(1)
+
+    try:
+        # Create minimal service instances for BrowserController
+        # Note: In real usage, these would come from ServiceContainer
+        websocket_service = WebSocketService(host="localhost", port_range=[8875, 8895])
+        browser_service = BrowserService()
+        applescript_service = AppleScriptService()
+
+        # Create browser controller
+        config = {
+            "browser_control": {
+                "mode": "cdp",
+                "cdp_port": cdp_port,
+                "cdp_enabled": True,
+                "fallback_enabled": False,
+            }
+        }
+        controller = BrowserController(
+            websocket_service=websocket_service,
+            browser_service=browser_service,
+            applescript_service=applescript_service,
+            config=config,
+        )
+
+        # Attempt connection
+        console.print("[cyan]→ Attempting CDP connection...[/cyan]\n")
+        result = await controller.connect_to_existing_browser(cdp_port=cdp_port)
+
+        if result["success"]:
+            # Show success table
+            table = Table(title="✓ Connection Successful", show_header=False)
+            table.add_column("Property", style="cyan", width=20)
+            table.add_column("Value", style="green")
+
+            table.add_row("Status", "[green]✓ Connected[/green]")
+            table.add_row("Browser Version", result.get("browser_version", "Unknown"))
+            table.add_row("CDP Port", str(result.get("cdp_port", cdp_port)))
+            table.add_row("Active Pages", str(result.get("page_count", 0)))
+
+            console.print(table)
+            console.print(
+                Panel(
+                    "[green]✓ Successfully connected to Chrome![/green]\n\n"
+                    "[bold]Next Steps:[/bold]\n"
+                    "  • Your browser session is preserved (cookies, extensions)\n"
+                    "  • Use MCP Browser tools with your existing browser\n"
+                    "  • Navigate, click, and interact while maintaining state\n\n"
+                    "[bold]Usage with Claude Code:[/bold]\n"
+                    "  Configure CDP mode in your config.json:\n"
+                    '  [dim]{"browser_control": {"mode": "cdp", "cdp_port": '
+                    + str(cdp_port)
+                    + "}}[/dim]",
+                    title="Connection Established",
+                    border_style="green",
+                )
+            )
+
+            # Clean up
+            await controller.close_cdp()
+
+        else:
+            console.print(
+                Panel(
+                    f"[red]✗ Connection failed[/red]\n\n"
+                    f"Error: {result.get('error', 'Unknown error')}\n\n"
+                    "[bold]Troubleshooting:[/bold]\n"
+                    f"  1. Ensure Chrome is running with --remote-debugging-port={cdp_port}\n"
+                    "  2. Check that no firewall is blocking the connection\n"
+                    "  3. Verify Playwright is installed: [cyan]playwright install[/cyan]\n\n"
+                    "[bold]Start Chrome with CDP:[/bold]\n"
+                    "  macOS:   /Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --remote-debugging-port="
+                    + str(cdp_port)
+                    + "\n"
+                    f"  Linux:   google-chrome --remote-debugging-port={cdp_port}\n"
+                    f'  Windows: chrome.exe --remote-debugging-port={cdp_port}',
+                    title="Connection Failed",
+                    border_style="red",
+                )
+            )
+            sys.exit(1)
+
+    except BrowserNotAvailableError as e:
+        console.print(
+            Panel(
+                f"[red]✗ Browser not available[/red]\n\n"
+                f"{str(e)}\n\n"
+                "[bold]How to start Chrome with CDP:[/bold]\n\n"
+                "[bold cyan]macOS:[/bold cyan]\n"
+                f'  /Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --remote-debugging-port={cdp_port}\n\n'
+                "[bold cyan]Linux:[/bold cyan]\n"
+                f"  google-chrome --remote-debugging-port={cdp_port}\n\n"
+                "[bold cyan]Windows:[/bold cyan]\n"
+                f'  "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe" --remote-debugging-port={cdp_port}\n\n'
+                "[dim]Note: Close all Chrome instances before starting with CDP[/dim]",
+                title="Browser Not Available",
+                border_style="red",
+            )
+        )
+        sys.exit(1)
+
+    except Exception as e:
+        console.print(
+            Panel(
+                f"[red]✗ Unexpected error[/red]\n\n"
+                f"Error: {str(e)}\n\n"
+                "Check the logs for more details.",
+                title="Error",
+                border_style="red",
+            )
+        )
+        import traceback
+
+        traceback.print_exc()
+        sys.exit(1)

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -16,6 +16,7 @@ from rich.panel import Panel
 from .._version import __version__
 from .commands import (
     browser,
+    connect,
     dashboard,
     doctor,
     extension,
@@ -185,6 +186,7 @@ def reference():
   [cyan]uninstall[/cyan]   - Remove MCP config from Claude
   [cyan]extension[/cyan]   - Manage Chrome extension
   [cyan]browser[/cyan]     - Browser interaction and testing
+  [cyan]connect[/cyan]     - Connect to existing Chrome via CDP
 
 [bold]Quick Start:[/bold]
   1. pip install mcp-browser
@@ -353,6 +355,7 @@ cli.add_command(install)
 cli.add_command(uninstall)
 cli.add_command(extension)
 cli.add_command(browser)
+cli.add_command(connect)
 
 
 def main():


### PR DESCRIPTION
## Summary
Adds support for connecting to an existing Chrome browser via Chrome DevTools Protocol (CDP), preserving user's cookies, sessions, and extensions.

## Changes
- Add `BrowserNotAvailableError` exception for CDP connection errors
- Add `connect_to_existing_browser(cdp_port=9222)` method to BrowserController:
  - Uses aiohttp to check CDP availability at `/json/version`
  - Uses Playwright's `connect_over_cdp` for connection
  - Returns browser version, page count, connection status
- Add CLI `connect` command with `--cdp-port` option:
  - Rich formatted output with connection status tables
  - Platform-specific instructions in error messages (macOS, Linux, Windows)
- Create comprehensive documentation in `docs/CDP_CONNECTION.md`:
  - Platform-specific instructions for starting Chrome with CDP
  - Troubleshooting section with common issues
  - Security considerations and best practices
  - FAQ section

## Usage
```bash
# Start Chrome with CDP enabled
/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --remote-debugging-port=9222

# Connect via CLI
mcp-browser connect --cdp-port 9222
```

## Test Plan
- [x] QA verification of all components
- [x] BrowserNotAvailableError exception defined
- [x] connect_to_existing_browser method implemented
- [x] CLI command with --cdp-port option
- [x] Rich formatting and error messages
- [x] Platform-specific instructions verified
- [x] Documentation complete

Closes #23

🤖 Generated with [Claude Code](https://claude.com/code)